### PR TITLE
Improve readability by not assembling URLs

### DIFF
--- a/llama.sh
+++ b/llama.sh
@@ -2,38 +2,56 @@
 # This software may be used and distributed according to the terms of the GNU General Public License version 3.
 
 #
-# UPDATE from Shawn (Mar 5 @ 2:43 AM): Facebook disabled this URL. I've mirrored the files to an R2 bucket, which this script now points to.
+# UPDATE from Shawn (Mar 5 @ 2:43 AM): Facebook disabled the original URL. I've mirrored the files to an R2 bucket, which this script now points to.
 #
-#PRESIGNED_URL="https://dobf1k6cxlizq.cloudfront.net/*?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9kb2JmMWs2Y3hsaXpxLmNsb3VkZnJvbnQubmV0LyoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE2NzgzNzA1MjR9fX1dfQ__&Signature=a387eZ16IkmbotdkEl8Z397Mvxhw4Bvk4SpEiDkqMLOMVMk5F962BzN5eKO-061g5vAEskn-CSrf4w3knubwPiFW69LTsJ8Amj-WOvtBOBy9soc43j77WGUU-3q2eNjMIyNZYsD~rub4EkUJGNpD61YtRrFvAU7tNQ1YMNL5-UUOk1~OHeaWerWisKPldufOyX6QdrrjeToVH1L0eGm1Ob4LnoYyLH96BHFou4XsOUR8NuyQfwYtmE2G6P2eKk~OV9-ABzYHxC2DyOWiWnt7WO~ELHnf17s9qreQAjEkCGEi4pHJ7BIkg6~ZfRmvRl3ZaPtqD80AH4SfO4hd5WQ0ng__&Key-Pair-Id=K231VYXPC1TA1R"             # replace with presigned url from email
 
-PRESIGNED_URL="https://agi.gpt4.org/llama/LLaMA/*"
-
-MODEL_SIZE="7B,13B,30B,65B"  # edit this list with the model sizes you wish to download
 TARGET_FOLDER="./"             # where all files should end up
-
-declare -A N_SHARD_DICT
-
-N_SHARD_DICT["7B"]="0"
-N_SHARD_DICT["13B"]="1"
-N_SHARD_DICT["30B"]="3"
-N_SHARD_DICT["65B"]="7"
+cd ${TARGET_FOLDER}
 
 echo "Downloading tokenizer"
-wget ${PRESIGNED_URL/'*'/"tokenizer.model"} -O ${TARGET_FOLDER}"/tokenizer.model"
-wget ${PRESIGNED_URL/'*'/"tokenizer_checklist.chk"} -O ${TARGET_FOLDER}"/tokenizer_checklist.chk"
+wget "https://agi.gpt4.org/llama/LLaMA/tokenizer.model" -O "tokenizer.model"
+wget "https://agi.gpt4.org/llama/LLaMA/tokenizer_checklist.chk" -O "tokenizer_checklist.chk"
+md5sum -c tokenizer_checklist.chk
 
-(cd ${TARGET_FOLDER} && md5sum -c tokenizer_checklist.chk)
+echo "Downloading 7B"
+mkdir "7B"
+wget "https://agi.gpt4.org/llama/LLaMA/7B/consolidated.00.pth" -O "7B/consolidated.00.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/7B/params.json" -O "7B/params.json"
+wget "https://agi.gpt4.org/llama/LLaMA/7B/checklist.chk" -O "7B/checklist.chk"
+echo "Checking checksums"
+(cd "7B" && md5sum -c checklist.chk)
 
-for i in ${MODEL_SIZE//,/ }
-do
-    echo "Downloading ${i}"
-    mkdir -p ${TARGET_FOLDER}"/${i}"
-    for s in $(seq -f "0%g" 0 ${N_SHARD_DICT[$i]})
-    do
-        wget ${PRESIGNED_URL/'*'/"${i}/consolidated.${s}.pth"} -O ${TARGET_FOLDER}"/${i}/consolidated.${s}.pth"
-    done
-    wget ${PRESIGNED_URL/'*'/"${i}/params.json"} -O ${TARGET_FOLDER}"/${i}/params.json"
-    wget ${PRESIGNED_URL/'*'/"${i}/checklist.chk"} -O ${TARGET_FOLDER}"/${i}/checklist.chk"
-    echo "Checking checksums"
-    (cd ${TARGET_FOLDER}"/${i}" && md5sum -c checklist.chk)
-done
+echo "Downloading 13B"
+mkdir "13B"
+wget "https://agi.gpt4.org/llama/LLaMA/13B/consolidated.00.pth" -O "13B/consolidated.00.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/13B/consolidated.01.pth" -O "13B/consolidated.01.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/13B/params.json" -O "13B/params.json"
+wget "https://agi.gpt4.org/llama/LLaMA/13B/checklist.chk" -O "13B/checklist.chk"
+echo "Checking checksums"
+(cd "13B" && md5sum -c checklist.chk)
+
+echo "Downloading 30B"
+mkdir "30B"
+wget "https://agi.gpt4.org/llama/LLaMA/30B/consolidated.00.pth" -O "30B/consolidated.00.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/30B/consolidated.01.pth" -O "30B/consolidated.01.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/30B/consolidated.02.pth" -O "30B/consolidated.02.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/30B/consolidated.03.pth" -O "30B/consolidated.03.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/30B/params.json" -O "30B/params.json"
+wget "https://agi.gpt4.org/llama/LLaMA/30B/checklist.chk" -O "30B/checklist.chk"
+echo "Checking checksums"
+(cd "30B" && md5sum -c checklist.chk)
+
+echo "Downloading 65B"
+mkdir "65B"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/consolidated.00.pth" -O "65B/consolidated.00.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/consolidated.01.pth" -O "65B/consolidated.01.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/consolidated.02.pth" -O "65B/consolidated.02.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/consolidated.03.pth" -O "65B/consolidated.03.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/consolidated.04.pth" -O "65B/consolidated.04.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/consolidated.05.pth" -O "65B/consolidated.05.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/consolidated.06.pth" -O "65B/consolidated.06.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/consolidated.07.pth" -O "65B/consolidated.07.pth"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/params.json" -O "65B/params.json"
+wget "https://agi.gpt4.org/llama/LLaMA/65B/checklist.chk" -O "65B/checklist.chk"
+echo "Checking checksums"
+(cd "65B" && md5sum -c checklist.chk)


### PR DESCRIPTION
Before running some script from the internet, I want to understand it. I found it unnecessarily cumbersome to read the script, so I'm suggestion some simplification here.