### PR TITLE
Update script URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To download all model weights, `cd` into the directory you want them, then run t
 Linux:
 
 ```sh
-curl -o- https://raw.githubusercontent.com/shawwn/llama-dl/56f50b96072f42fb2520b1ad5a1d6ef30351f23c/llama.sh | bash
+curl -o- https://raw.githubusercontent.com/Elyah2035/llama-dl/main/llama.sh | bash
 ```
 
 Mac:
@@ -52,7 +52,7 @@ brew install bash
 brew install wget
 ```
 ```sh
-curl -o- https://raw.githubusercontent.com/shawwn/llama-dl/56f50b96072f42fb2520b1ad5a1d6ef30351f23c/llama.sh | $(brew --prefix)/bin/bash
+curl -o- https://raw.githubusercontent.com/Elyah2035/llama-dl/main/llama.sh | $(brew --prefix)/bin/bash
 ```
 
 (Sorry mac users; they use some array syntax in the script that isn't supported on the version of bash that ships with Mac.)


### PR DESCRIPTION
The current URL shows a 404 response. I replaced the URL so that it's always up-to-date and not dependent on specific commit.